### PR TITLE
Keep voice packets in order when the sequence counter wraps

### DIFF
--- a/lib/services/bluetooth_reciever.dart
+++ b/lib/services/bluetooth_reciever.dart
@@ -271,6 +271,7 @@ class BluetoothReciever {
 class VoiceDataCollector {
   final Map<int, List<int>> _chunks = {};
   int seqAdd = 0;
+  int? _lastSeq;
   final m = Mutex();
 
   bool isRecording = false;
@@ -363,9 +364,13 @@ class VoiceDataCollector {
 
   Future<void> addChunk(int seq, List<int> data) async {
     await m.acquire();
-    if (seq == 255) {
-      seqAdd += 255;
+    // The sequence byte wraps every 256 packets (~25s of audio). Detect the wrap by the
+    // counter going backwards and advance by a full 256: bumping on seq == 255 moved that
+    // packet past the whole next lap, and advancing by 255 made lap 3 overwrite lap 1.
+    if (_lastSeq != null && seq < _lastSeq! - 128) {
+      seqAdd += 256;
     }
+    _lastSeq = seq;
     _chunks[seqAdd + seq] = data;
     m.release();
 
@@ -410,6 +415,7 @@ class VoiceDataCollector {
   void reset({bool skipWakeWordCheck = false}) {
     _chunks.clear();
     seqAdd = 0;
+    _lastSeq = null;
     if (!skipWakeWordCheck) {
       _processPCMTicker?.cancel();
       _processPCMTicker = null;

--- a/test/voice_data_collector_test.dart
+++ b/test/voice_data_collector_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fahrplan/services/bluetooth_reciever.dart';
+
+void main() {
+  group('VoiceDataCollector', () {
+    test('keeps every packet when the sequence counter wraps', () async {
+      final collector = VoiceDataCollector();
+
+      // Three laps of the 0..255 counter, i.e. roughly 77 seconds of speech.
+      for (int lap = 0; lap < 3; lap++) {
+        for (int seq = 0; seq < 256; seq++) {
+          await collector.addChunk(seq, [lap, seq]);
+        }
+      }
+
+      expect(collector.getAllData().length, 3 * 256 * 2);
+    });
+
+    test('keeps packets in the order they were spoken', () async {
+      final collector = VoiceDataCollector();
+      final expected = <int>[];
+
+      for (int lap = 0; lap < 2; lap++) {
+        for (int seq = 0; seq < 256; seq++) {
+          await collector.addChunk(seq, [lap, seq]);
+          expected.addAll([lap, seq]);
+        }
+      }
+
+      expect(collector.getAllData(), expected);
+    });
+
+    test('reset clears the wrap state', () async {
+      final collector = VoiceDataCollector();
+
+      for (int seq = 250; seq < 256; seq++) {
+        await collector.addChunk(seq, [seq]);
+      }
+      collector.reset(skipWakeWordCheck: true);
+      await collector.addChunk(0, [42]);
+
+      expect(collector.getAllData(), [42]);
+    });
+  });
+}


### PR DESCRIPTION
Hi! Thanks for fahrplan — while building a macOS BLE gateway for the G1 I went looking for a working implementation of the glasses' microphone, and this is the only one I found. Along the way I hit a small bug in `VoiceDataCollector`.

### The problem

The sequence byte of `0xF1` packets wraps every 256 packets, which is about 25 seconds of audio. `addChunk` handles the wrap like this:

```dart
if (seq == 255) {
  seqAdd += 255;
}
_chunks[seqAdd + seq] = data;
```

Two things go wrong with longer recordings:

1. **Packet 255 lands ~25s too late.** Its key becomes `255 + 255 = 510`, while the next lap occupies keys `255..509`. Since `getAllData()` sorts by key, that 100 ms of speech is spliced in after the whole following lap.
2. **From the third lap packets are silently overwritten.** Because the bump is 255 rather than 256, lap 3 starts at key 510 again — which packet 255 of lap 1 already took. One packet is lost per lap after that.

Concretely, feeding three full laps (768 packets, ~77 s):

| | packets kept | order around the first wrap |
|---|---|---|
| before | 767 | `252, 253, 254, 0, 1, 2` |
| after | 768 | `252, 253, 254, 255, 0, 1` |

This mostly affects the longer recordings — voice notes fetched from the glasses and the wake-word buffer — rather than short Even AI queries.

### The fix

Detect the wrap by the counter going backwards, advance by a full 256, and clear the state in `reset()`.

### Tests

Added `test/voice_data_collector_test.dart` with three cases: no packet is dropped across three wraps, order matches the order things were spoken, and `reset()` clears the wrap state. I checked they fail on `main` and pass with the patch (`flutter test`, Flutter 3.44.9).

Note: `test/time_weather_test.dart` fails for me on a clean checkout too (looks timezone-dependent) — unrelated to this change.